### PR TITLE
Add Glitchfinder's Integrated Addons.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -163,6 +163,23 @@
             <span id="Changelog" class="section">
                 <h2 onclick="location.href='#Changelog'">Changelog (DD/MM/YY)</h2>
 
+                <div class="expander-top clickable" onclick="expandCard(this, year2025expander)" id="year2025">
+                    <p>
+                    <h3>2025</h3>
+                    <img class="chevron" style="transform: rotateX(0deg);" src="img/UI/Chevron Down.svg" alt="UI element - Chevron">
+                    </p>
+                </div>
+                <div class="expander-bottom" id="year2025expander">
+                    <p>
+                    <h2 class="install">12/03/25</h2>
+                    <h3>NOT Safe Mid-game</h3>
+                    <h2><strong>Gameplay</strong></h2>
+                    <ul>
+                        <li>Added Integrated Addons.</li>
+                        <li>Removed Integrated Automatron and Simple Creation Club Delayed NG.</li>
+                    </ul>
+                </div>
+
                 <div class="expander-top clickable" onclick="expandCard(this, year2024expander)" id="year2024">
                     <p>
                     <h3>2024</h3>

--- a/faq.html
+++ b/faq.html
@@ -704,7 +704,7 @@ DC - Outside DC 6.83s
                     </p>
                 </div>
                 <div class="expander-bottom" id="gameplayquestion1expander">
-                    Read <a href="https://www.nexusmods.com/fallout4/mods/85317" target="_blank">Integrated Automatron</a>'s description.
+                    Read <a href="https://www.nexusmods.com/fallout4/mods/92016?tab=logs" target="_blank">Integrated Addons</a>'s changelogs.
                 </div>
             </span>
 

--- a/gameplay.html
+++ b/gameplay.html
@@ -238,24 +238,13 @@
                     </p>
                 </div>
 
-                <div class="card" id="IntegratedAutomatron">
+                <div class="card" id="IntegratedAddons">
                     <p>
-                    <h3 class="link-download"><a href="https://www.nexusmods.com/fallout4/mods/85317" target="_blank">Integrated Automatron</a></h3>
-                    Alters how Automatron is handled to have it behave more like base game content rather than announcing its presence to the world as soon as you hit level fifteen.
+                    <h3 class="link-download"><a href="https://www.nexusmods.com/fallout4/mods/92016" target="_blank">Integrated Addons</a></h3>
+                    Alters how the DLC and next-gen Creation Club addons are handled to have them behave more like base game content.
                     <h3 class="install">Installation instructions</h3>
                     <ul>
-                        <li><b>Main Files</b> - Integrated Automatron</li>
-                    </ul>
-                    </p>
-                </div>
-
-                <div class="card" id="CreationClubDelayed">
-                    <p>
-                    <h3 class="link-download"><a href="https://www.nexusmods.com/fallout4/mods/84393" target="_blank">Simple Creation Club Delayed NG</a></h3>
-                    Delays the start of the Next Gen Creation Club content until certain requirements are met.
-                    <h3 class="install">Installation instructions</h3>
-                    <ul>
-                        <li><b>Main Files</b> - Simple Creation Club Delayed NG</li>
+                        <li><b>Main Files</b> - Integrated Addons</li>
                     </ul>
                     </p>
                 </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,19 +6,9 @@
 		<lastmod>2023-04-08</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/avoid-mods.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/index.html</loc>
 		<priority>0.80</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/avoid-tools.html</loc>
-		<priority>0.80</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/faq.html</loc>
-		<priority>0.80</priority>
-		<lastmod>2025-02-01</lastmod>
+		<lastmod>2023-04-08</lastmod>
 	</url>
 	<url>
 		<loc>https://themidnightride.moddinglinked.com/intro.html</loc>
@@ -26,9 +16,19 @@
 		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/index.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/faq.html</loc>
 		<priority>0.80</priority>
-		<lastmod>2023-04-08</lastmod>
+		<lastmod>2025-03-12</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/avoid-tools.html</loc>
+		<priority>0.80</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/avoid-mods.html</loc>
+		<priority>0.80</priority>
+		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
 		<loc>https://themidnightride.moddinglinked.com/lod.html</loc>
@@ -36,37 +36,7 @@
 		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/finish.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/visuals.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/gameplay.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/hud.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/tweaks.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/bugfix.html</loc>
-		<priority>0.64</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/utilities.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/setup.html</loc>
 		<priority>0.64</priority>
 		<lastmod>2025-02-01</lastmod>
 	</url>
@@ -76,9 +46,44 @@
 		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/setup.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/utilities.html</loc>
 		<priority>0.64</priority>
 		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/bugfix.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/tweaks.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/hud.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/gameplay.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-03-12</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/visuals.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/finish.html</loc>
+		<priority>0.64</priority>
+		<lastmod>2025-02-01</lastmod>
+	</url>
+	<url>
+		<loc>https://themidnightride.moddinglinked.com/changelog.html</loc>
+		<priority>0.51</priority>
+		<lastmod>2025-03-12</lastmod>
 	</url>
 	<url>
 		<loc>https://themidnightride.moddinglinked.com/resources.html</loc>
@@ -86,17 +91,12 @@
 		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/changelog.html</loc>
-		<priority>0.51</priority>
-		<lastmod>2025-02-01</lastmod>
-	</url>
-	<url>
-		<loc>https://themidnightride.moddinglinked.com/basefinish.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/wabbajack.html</loc>
 		<priority>0.50</priority>
 		<lastmod>2025-02-01</lastmod>
 	</url>
 	<url>
-		<loc>https://themidnightride.moddinglinked.com/wabbajack.html</loc>
+		<loc>https://themidnightride.moddinglinked.com/basefinish.html</loc>
 		<priority>0.50</priority>
 		<lastmod>2025-02-01</lastmod>
 	</url>


### PR DESCRIPTION
Replaces Integrated Automatron and Simple Creation Club Delayed NG.
Wabbajack requires an update on Ungeziefi's end.