### PR TITLE
Fix expander glitchy animation on firefox. Simplify expandCard code

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -100,7 +100,7 @@ span.card-basic {
   background-color: rgba(255, 255, 255, 0.0512);
 }
 
-.expander-top.active {
+.expander-top[aria-expanded="true"] {
   background-color: rgba(255, 255, 255, 0.0612);
 }
 
@@ -119,16 +119,23 @@ span.card-basic {
 
 .expander-bottom {
   background-color: rgba(255, 255, 255, 0.0512);
-  display: none;
-  animation: slide-up 0.4s;
-  z-index: 0;
-  position: relative;
-  overflow-y: hidden;
   margin-top: 0 !important;
+  max-height: 0;
+  opacity: 0;
+  overflow-y: hidden;
+  transition: max-height 300ms ease, opacity 300ms ease;
 }
 
-.expander-opened {
-  animation: slide-down 2s;
+.expander-top[aria-expanded="true"] ~ .expander-bottom {
+  opacity: 1;
+}
+
+.expander-top[aria-expanded="true"] .chevron {
+  transform: rotate(180deg)!important;
+}
+
+.chevron {
+  transition: transform 300ms ease;
 }
 
 /* Chevron icon */

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -45,9 +45,9 @@ function fadeOut(element) {
     element.style.opacity = "0%";
 }
 
-function rotate(element, rotation = 180) {
-    element.style.transform = 'rotatex(' + rotation + 'deg)';
-}
+// function rotate(element, rotation = 180) {
+//     element.style.transform = 'rotatex(' + rotation + 'deg)';
+// }
 
 function setupExpanders() {
     const expanders = document.querySelectorAll('.expander-top');
@@ -77,26 +77,20 @@ function setupExpanders() {
     });
 }
 
-function expandCard(thisObj, $open, $dontReset) {
-    const chevron = thisObj.getElementsByClassName("chevron")[0]
-    if ($open.classList.contains('expander-opened') && !$dontReset) {
-        rotate(chevron, 0)
-        $open.classList.remove('expander-opened');
-        setTimeout(() => $open.style.display = "none", 400);
-        thisObj.classList.remove('active');
+function expandCard(thisObj, $open) {
+    if (thisObj.getAttribute('aria-expanded')) {
+        thisObj.removeAttribute('aria-expanded');
+        $open.style.maxHeight = 0;
     }
     else {
-        $open.classList.add('expander-opened');
-        rotate(chevron, 180);
-        $open.style.display = "block";
-        thisObj.classList.add('active');
-
-        const textareas = $open.querySelectorAll('.auto-resize');
-        if (textareas) {
-            for (var i = 0; i < textareas.length; i++) {
-                autoResize(textareas[i]);
-            }
-        }
+        thisObj.setAttribute('aria-expanded', 'true');
+        $open.style.maxHeight = $open.scrollHeight + 'px';
+        // const textareas = $open.querySelectorAll('.auto-resize');
+        // if (textareas) {
+        //     for (var i = 0; i < textareas.length; i++) {
+        //         autoResize(textareas[i]);
+        //     }
+        // }
     }
 }
 


### PR DESCRIPTION
# Summary:
Fixed expander glitch on Firefox and Edge (not as rough). Simplifies the logic in expandCard. Commented out rotate() helper function in favor of pure css animation.  Also added aria-expanded for accessibility.

## What changed:
- Comment out rotate() helper and nuke the calls.
- Rewrote expandCard, simplified and make it use aria-expanded on trigger element.
- Tune the css a bit so that it works with the modified expandCard.

## Why:
- Expander goes glitchy on Firefox and Edge, i believe it's because of mixing display toggles with CSS height transition. Changed it to use opacity and max-height instead for the fix. 

https://github.com/user-attachments/assets/1bd74edd-49a3-4cd9-9cfb-b2333f48ad85

https://github.com/user-attachments/assets/e1ec3bfa-ff99-4bc3-a1c1-d29e28579448

- Used aria-expanded because it improves accessibility a bit.

## Notes & Possible follow-ups:
Direct inline styles is pretty dirty but its hard to do clean on current element structure. I'm suggesting to change the expander structure from:
```html
  <div class="expander-top">
    <p>
    <h3>_</h3>
    <img class="chevron" style="transform: rotateX(0deg);" src="img/UI/Chevron Down.svg" alt="UI element - Chevron">
    </p>
  </div>
  <div class="expander-bottom">
    <p> _ </p>
  </div>
```
to:
```html
  <details class="expander">
    <summary class="expander-header">
      <h3>Header...</h3>
    </summary>
    <img class="chevron" src="img/UI/Chevron Down.svg" alt="UI element - Chevron">
    <div class="expander-content">Content...</div>
  </details>
```
With that it's possible to put css variable on .expander and do something like `el.style.setProperty('--expander-height', val)`. New structure also gave even more accessibility too. Just gave the green light and I'll cook them up.