### PR TITLE
Set PostloadingMenuSpeed to 2.0 to prevent freezing

### DIFF
--- a/utilities.html
+++ b/utilities.html
@@ -420,7 +420,7 @@
                             <li>Change only the following options:</li>
                             <ul>
                                 <li>Set <b>DisableBlackLoadingScreens</b> to <strong>true</strong>.</li>
-                                <li>Set <b>PostloadingMenuSpeed</b> to <strong>3.0</strong>.</li>
+                                <li>Set <b>PostloadingMenuSpeed</b> to <strong>2.0</strong>.</li>
                                 <li>Set <b>OneThreadWhileLoading</b> to <strong>false</strong>.</li>
                                 <li>Use the calculator below to determine your <strong>optimal FPS limit</strong> setting. You can find your exact refresh rate <b><a href="https://www.testufo.com/refreshrate" target="_blank">here</a></b>.</li>
 


### PR DESCRIPTION
Multiple people have reported that they've had load menu freezing issues with PostloadingMenuSpeed set to 3.0, and that setting that option to 2.0 fixed it, this Pull Request changes PostloadingMenuSpeed to 2.0 to prevent this issue.
